### PR TITLE
Moved vue dependency to peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "isy",
   "license": "MIT",
   "private": false,
-  "dependencies": {
+  "peerDependencies": {
     "vue": "^2.6.10"
   },
   "devDependencies": {


### PR DESCRIPTION
With vue as a dependency it breaks any other packages from a regular workflow, as it installs vue, rather than just expecting it which is absolutely enough, as someone using the `vue-toc` is expected to have vue anyway.

Packages are broken as in the case of multiple folders as it often happens with libraries it would introduce two separate vue packages and it would eventually break reactivity, and many other very hard to detect/understand errors.